### PR TITLE
Draft version. Incomplete

### DIFF
--- a/lambda/aggregator/IntersectionAggregator.js
+++ b/lambda/aggregator/IntersectionAggregator.js
@@ -1,0 +1,25 @@
+/**
+ * List of lists
+ * @param {*} movies 
+ */
+var aggregate = function(movies) {
+    if (movies.length == 0) {
+        return [];
+    }
+
+    if (movies.length == 1) {
+        return movies[0];
+    }
+
+    // extracts the first movie list of the movies list and then checks each movie in the first movie list if
+    // every other movie list contains the same movie
+    return movies.shift().filter(function(movie) {
+        return movies.every(function(m) {
+            return m.some(elem => elem.equals(movie));
+        });
+    });
+};
+
+module.exports = {
+    aggregate: aggregate
+}

--- a/lambda/dispatcher/SourceDispatcher.js
+++ b/lambda/dispatcher/SourceDispatcher.js
@@ -1,0 +1,51 @@
+var SlotConstants = require('../model/Slots');
+var wikiQuoteSource = require('../source/WikiQuoteSource');
+
+/**
+ * 
+ * @param {*} queryInfo 
+ */
+var dispatch = function(queryInfo) {
+    // create a list of movies. This is to store the movie lists returned from each source.
+    // what slots (information) do we know
+    const slots = queryInfo['slots'];
+    // sessionAttributes can store previous information state i.e. data
+    var sessionAttributes = queryInfo['sessionAttributes'];
+
+    var sourcePromises = [];
+
+    return new Promise(function(resolve, reject) {
+        if (slots.hasOwnProperty(SlotConstants.MOVIEQUOTE)) {
+            console.log("WikiQuote source is added");
+            const quote = slots[SlotConstants.MOVIEQUOTE];
+            sourcePromises.push(wikiQuoteSource.getMovies(quote));
+            // if (sessionAttributes.hasOwnProperty('MovieQuote')) {
+            //     // something like getting previous results from session attributes or could be from dynamodb
+            //     const wikiQuoteMovies = sessionAttributes['MovieQuote'];
+            //     movies.push(wikiQuoteMovies);
+            // } else {
+            //     const quote = slots[SlotConstants.MOVIEQUOTE];
+            //     wikiQuoteSource.getMovies(quote).then((wikiQuoteMovies) => {
+            //         movies.push(wikiQuoteMovies);
+            //         // TODO need to find way to store it in session attributes. won't work adding in a list..
+            //         sessionAttributes['MovieQuote'] = wikiQuoteMovies;
+            //     }).catch((err) => {
+            //         reject(err);
+            //     });
+            // }
+        }
+
+        // Other sources. Not sure how it will work
+
+        Promise.all(sourcePromises).then(sourceMovies => {
+            resolve(sourceMovies);
+        }).catch((err) => {
+            reject(err);
+        });
+    });
+
+};
+
+module.exports = {
+    dispatch: dispatch
+};

--- a/lambda/model/Movie.js
+++ b/lambda/model/Movie.js
@@ -8,6 +8,10 @@ class Movie {
     getTitle() {
         return this.title;
     }
+
+    equals(otherMovie) {
+        return this.title == otherMovie.getTitle();
+    }
 }
 
 var builder = function(title) {

--- a/lambda/model/Slots.js
+++ b/lambda/model/Slots.js
@@ -1,0 +1,5 @@
+const MOVIEQUOTE = 'MovieQuote';
+
+module.exports = {
+    MOVIEQUOTE: MOVIEQUOTE
+};

--- a/lambda/movieFinder.js
+++ b/lambda/movieFinder.js
@@ -1,16 +1,17 @@
+var sourceDispatcher = require('dispatcher/SourceDispatcher');
+var aggregator = require('aggregator/IntersectionAggregator');
+
 var find = function(slots, sessionAttributes) {
     queryInfo = {
-        slots : slots,
+        slots: slots,
         sessionAttributes: sessionAttributes
     };
 
     return new Promise(function(resolve, reject) {
         validateSlots(queryInfo)
-        .then(findMovieFromSources(queryInfo))
-        .then(processMovieList(movieLists))
-        .then((singleMovieList) => {
-            resolve(singleMovieList);
-        })
+        .then(() => findMovieFromSources(queryInfo))
+        .then((movieLists) => processMovieLists(movieLists))
+        .then((singleMovieList) => resolve(singleMovieList))
         .catch((err) => {
             reject(err);
         });
@@ -27,23 +28,38 @@ var find = function(slots, sessionAttributes) {
  */
 function validateSlots(queryInfo) {
     return new Promise(function(resolve, reject){
-
+        resolve(queryInfo);
     });
 }
 
+/**
+ * Finds movies from the sources based on the provided queryInfo
+ * @param {*} queryInfo 
+ */
 function findMovieFromSources(queryInfo) {
+    console.log("Finding movie from sources");
     return new Promise(function(resolve, reject) {
-
+        sourceDispatcher.dispatch(queryInfo).then((movies) => {
+            console.log("Received movies from sources");
+            console.log(movies);
+            resolve(movies);
+        }).catch((err) => {
+            reject(err);
+        });
     });
 }
 
 
 function processMovieLists(movieLists) {
-    return new Promise(function(resolve, reject){
-
+    console.log("Processing movie list");
+    return new Promise(function(resolve, reject) {
+        const movieList = aggregator.aggregate(movieLists);
+        console.log("Aggregated movies");
+        console.log(movieList);
+        resolve(movieList);
     });
 }
 
-modules.exports = {
+module.exports = {
     find : find
 }

--- a/lambda/moviebotFunction.js
+++ b/lambda/moviebotFunction.js
@@ -3,6 +3,7 @@
 var rp = require('request-promise');
 var tmdbClient = require('source/tmdbSource');
 var wikiQuoteSource = require('source/WikiQuoteSource');
+var movieFinder = require('movieFinder');
 
  /**
   * This sample demonstrates an implementation of the Lex Code Hook Interface
@@ -220,7 +221,7 @@ function findMovieOld(intentRequest, callback) {
 
 function findMovie(intentRequest, callback) {
     const sessionAttributes = intentRequest.sessionAttributes || {};
-    const slots = intentRequest.slots;
+    const slots = intentRequest.currentIntent.slots;
 
     movieFinder.find(slots, sessionAttributes).then((singleMovieList) => {
         //movieFinder will return a list of movie result


### PR DESCRIPTION
Incomplete but created it to ask for discussion. I'm unsure how the source dispatcher should behave for sources like tmdb. For example, if we are given slots and it has PlotDescription only. We can get the movies for it and return it. If another request comes in and it has PlotDescription and Actors, assuming we stored results in sessionAttributes (or some other place) we can filter the existing movies with actors. How about other way round? Actors first then PlotDescription. If the movies returned from either call, returns all the information, we only need to make one call? Or do they support a REST call?

Also how are we going to store previous results in sessionAttributes or some other place? The sessionAttributes only allows string to string mappings.