### PR TITLE
Always check for slots first

### DIFF
--- a/lambda/dispatcher/SourceDispatcher.js
+++ b/lambda/dispatcher/SourceDispatcher.js
@@ -59,13 +59,13 @@ var dispatch = function(queryInfo) {
 };
 
 function retrieveInfo(slotName, queryInfo) {
-    if (queryInfo.sessionAttributes.hasOwnProperty(slotName)) {
-        return queryInfo.sessionAttributes[slotName];
-    }
-
     if (queryInfo.slots.hasOwnProperty(slotName)) {
         queryInfo.sessionAttributes[slotName] = queryInfo.slots[slotName];
         return queryInfo.slots[slotName];
+    }
+    
+    if (queryInfo.sessionAttributes.hasOwnProperty(slotName)) {
+        return queryInfo.sessionAttributes[slotName];
     }
 
     return null;


### PR DESCRIPTION
Quick fix for overriding old query information in session attributes. Basically it should check for slots first and override any information stored in session attributes