### PR TITLE
hotfix for movie without trailer

### DIFF
--- a/lambda/trailer/YoutubeTrailer.js
+++ b/lambda/trailer/YoutubeTrailer.js
@@ -29,24 +29,23 @@ var apply = function(movieList) {
                         if (res.items.length == 0) {
                             // log that no trailers were found.
                             console.log("No trailers were found");
+                        } else {
+                            // extract most relevant item
+                            const item = res.items[0];
+
+                            const videoId = item.id.videoId;
+                            const trailerDescription = item.snippet.description;
+                            const trailerThumbnail = item.snippet.thumbnails.high.url;
+
+                            const trailerUrl = "https://www.youtube.com/watch?v=" + videoId;
+
+                            movie.setTrailerUrl(trailerUrl);
+                            movie.setTrailerDescription(trailerDescription);
+                            movie.setTrailerThumbnail(trailerThumbnail);
                         }
-
-                        // extract most relevant item
-                        const item = res.items[0];
-
-                        const videoId = item.id.videoId;
-                        const trailerDescription = item.snippet.description;
-                        const trailerThumbnail = item.snippet.thumbnails.high.url;
-
-                        const trailerUrl = "https://www.youtube.com/watch?v=" + videoId;
-
-                        movie.setTrailerUrl(trailerUrl);
-                        movie.setTrailerDescription(trailerDescription);
-                        movie.setTrailerThumbnail(trailerThumbnail);
-
                         resolve(movie);
                     }).catch(function(err) {
-                        reject();
+                        reject(err);
                     });
             });
         });


### PR DESCRIPTION
e.g. 
search for plot "Unglassed Windows Cast a Terrible Reflection"

Previously moviebot would glitch and not give a response as the movie trailer was not found

Updated so now it returns a response card with no trailer link:
![image](https://user-images.githubusercontent.com/8232529/27992898-9991e0b8-64f2-11e7-9658-e68aaec97915.png)
